### PR TITLE
add_errorhandling to new_item_view

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -15,7 +15,7 @@ $(function(){
     var childSelectHtml = '';
     childSelectHtml = `
                         <div class='main__box__detail__category__form__box'  id= 'children_wrapper'>
-                          <select class="listing-select-wrapper__box--select" id="child_category" name="">
+                          <select class="listing-select-wrapper__box--select" id="child_category" name="" required="required">
                             <option value="---" data-category="---">---</option>
                             ${insertHTML}
                           <select>
@@ -29,7 +29,7 @@ $(function(){
   function appendGrandchidrenBox(insertHTML){
     var grandchildSelectHtml = '';
     grandchildSelectHtml = `<div class='main__box__detail__category__form__box' id= 'grandchildren_wrapper'>
-                              <select class="listing-select-wrapper__box--select" id="grandchild_category" name="category_id">
+                              <select class="listing-select-wrapper__box--select" id="grandchild_category" name="category_id" required="required">
                                 <option value="---" data-category="---">---</option>
                                   ${insertHTML}
                               </select>

--- a/app/assets/javascripts/ship.js
+++ b/app/assets/javascripts/ship.js
@@ -39,7 +39,7 @@ $(function(){
                           <span class='listing-default--require'>必須</span>
                             <div class='listing-select-wrapper__box'>
                               <div class='listing-select-wrapper'></div>
-                                <select class="listing-select-wrapper__box--select" id="delivery_charge" name="item[ship_method]">
+                                <select class="listing-select-wrapper__box--select" id="delivery_charge" name="item[ship_method]" required="required">
                                   <option value="---">---</option>
                                   ${insertHTML}
                                 </select>

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -20,7 +20,7 @@
                 .main__box__image__form__in__box
                   = form.fields_for :images do |image|
                     -# .input_area
-                    = image.file_field :image, type: 'file', name: "item[images_attributes][][image]", value:"", style: "display:none", id:"img-file"
+                    = image.file_field :image, type: 'file', name: "item[images_attributes][][image]", value:"", style: "display:none", id:"img-file", :required => ""
                     
                   .main__box__image__form__in__box__text
                     .main__box__image__form__in__box__text__icon
@@ -40,7 +40,7 @@
             .main__box__NameAndDescripution__itemname__form
               .main__box__NameAndDescripution__itemname__form__box
                 -# %input.itemnameform{:placeholder => "40文字まで"}/
-                = form.text_field :name, {placeholder:  '40文字まで',class: 'itemnameform'}
+                = form.text_field :name, {placeholder:  '40文字まで',class: 'itemnameform', :required => ""}
           .main__box__NameAndDescripution__itemDescription
             .main__box__NameAndDescripution__itemDescription__sentence
               商品の説明
@@ -53,7 +53,7 @@
                 #textLest 1000
                 %span.remaining-counter 文字入力できます。
                 -# #textAttention 入力文字数が多すぎます。
-                =form.text_area :description, {id: "textArea", cols:"40", rows:"15", placeholder: "商品の説明 (必須 1,000字以内)\n (色、素材、、素材、重さ、、素材、重さ、定価、注意点など)\n\n例)2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。合わせやすいのでおすすめです。"}      
+                =form.text_area :description, {id: "textArea", cols:"40", rows:"15", placeholder: "商品の説明 (必須 1,000字以内)\n (色、素材、、素材、重さ、、素材、重さ、定価、注意点など)\n\n例)2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。合わせやすいのでおすすめです。", :required => ""}      
 
         .main__box__detail
           .main__box__detail__text
@@ -65,7 +65,7 @@
                 必須
             .main__box__detail__category__form
               .main__box__detail__category__form__box
-                = form.select :category, @category_parent_array, {:prompt => "---" }, {class: 'listing-select-wrapper__box--select', id: 'parent_category', name:""} # @category_parent_arrayには、parent.nameが入っている。
+                = form.select :category, @category_parent_array, {:prompt => "---" }, {class: 'listing-select-wrapper__box--select', id: 'parent_category', name:"", :required => ""} # @category_parent_arrayには、parent.nameが入っている。
                 // @category_parent_arrayの内容を選択肢に表示
 
           .main__box__detail__bland
@@ -84,7 +84,7 @@
                 必須
             .main__box__detail__status__form
               .main__box__detail__status__form__box
-                = form.select :condition, Item.conditions, {}, {class: 'itemnameform'}
+                = form.select :condition, Item.conditions, {}, {class: 'itemnameform', :required => ""}
 
 
         .main__box__delivery
@@ -97,7 +97,7 @@
               %span 必須
               .main__box__delivery__fee__form
                 .main__box__delivery__fee__form__box
-                  = form.select :ship_charge, Item.ship_charges, {}, {class: 'itemnameform',id:"ship_charge"}
+                  = form.select :ship_charge, Item.ship_charges, {}, {class: 'itemnameform',id:"ship_charge", :required => ""}
                   
           .listing-product-delivery-charge-burden
                 
@@ -107,7 +107,7 @@
               %span 必須
               .main__box__delivery__area__form
                 .main__box__delivery__area__form__box
-                  = form.select :ship_area, Item.ship_areas, {}, {class: 'itemnameform'}
+                  = form.select :ship_area, Item.ship_areas, {}, {class: 'itemnameform', :required => ""}
 
           .main__box__delivery__day
             .main__box__delivery__day__text
@@ -115,7 +115,7 @@
               %span 必須
               .main__box__delivery__day__form
                 .main__box__delivery__day__form__box
-                  = form.select :ship_date, Item.ship_dates, {}, {class: 'itemnameform'}
+                  = form.select :ship_date, Item.ship_dates, {}, {class: 'itemnameform', :required => ""}
                 .main__box__delivery__day__form__alert
               
         .main__box__price
@@ -132,7 +132,7 @@
                   ¥
                 .main__box__price__value__wrapper__form__input
                   .main__box__price__value__wrapper__form__input__box
-                    = form.number_field :price, {placeholder: '0'}
+                    = form.number_field :price, {placeholder: '0', :required => ""}
                   .main__box__price__value__wrapper__form__input__error
 
             .main__box__price__value__commission


### PR DESCRIPTION
# What
出品画面にエラーハンドリングを追加

# Why
空出品を防ぐため